### PR TITLE
fix: change module type to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "remark-sugar-high",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "remark plugin of sugar high syntax highlighter",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The remark plugin itself is already in ESM, having this plugin in CJS will break the plugin sometimes due to the `ERR_REQUIRE_ESM` error. Hence we just migrate the plugin into ESM. Luckily bundler `bunchee` already supports it by just changing adding the `"type": "module"` for our case

Fixes #4
Fixes #5